### PR TITLE
Bug fix in cfg settings

### DIFF
--- a/docker/scripts/cluster.sh
+++ b/docker/scripts/cluster.sh
@@ -145,7 +145,7 @@ function bind_mesh {
         let peer_port=$(($peer_port_begin + $i - 1))
         let user_port=$(($user_port_begin + $i - 1))
 
-        jq ".contract.id=$contract_id | .contract.roundtime=2000 | .mesh.port=$peer_port | .user.port=$user_port" $cfg_file > $cfg_file.tmp \
+        jq ".contract.id=$contract_id | .contract.consensus.roundtime=2000 | .mesh.port=$peer_port | .user.port=$user_port" $cfg_file > $cfg_file.tmp \
             && mv $cfg_file.tmp $cfg_file
 
         all_pubkeys[i]=$(jq --raw-output ".node.public_key" $cfg_file)


### PR DESCRIPTION
The bind_mesh function is hardcoding contract.roundtime=2000 (2 seconds) into the configuration incorrectly causing a duplicate roundtime setting in the default of 1000 irrespective of what contract.roundtime=2000 or what the hp.cfg.override is set to.

It should be setting this to contract.consensus.roundtime.

Currently, setting roundtime in hp.cfg.override in hpdevkit has no effect on consensus roundtime and it perists at 1000ms.

```
cat /var/lib/docker/volumes/hpdevkit_default_vol/_data/node1/cfg/hp.cfg | grep -A10 -B5 roundtime
    "bin_args": "index.js",
    "environment": {},
    "max_input_ledger_offset": 10,
    "consensus": {
      "mode": "public",
      "roundtime": 1000,   <-------- should be here
      "stage_slice": 25,
      "threshold": 80
    },
    "npl": {
      "mode": "private"
    },
    "round_limits": {
      "user_input_bytes": 0,
      "user_output_bytes": 0,
      "npl_output_bytes": 0,
      "proc_cpu_seconds": 0,
      "proc_mem_bytes": 0,
      "proc_ofd_count": 0,
      "exec_timeout": 300000
    },
    "roundtime": 2000   <------- should not be here
  },
  "mesh": {
    "port": 22861,
    "listen": true,
    "idle_timeout": 120000,
    "known_peers": [
      "node2:22862",
      "node3:22863"
    ],
    "msg_forwarding": true,
```