### PR TITLE
Fix sync_instance bundle copy — use /. to copy contents not directory

### DIFF
--- a/docker/scripts/cluster.sh
+++ b/docker/scripts/cluster.sh
@@ -277,7 +277,7 @@ function sync_instance {
     local contract_dir=$(contract_dir_mount_path $node)
     rm -rf $contract_dir/ledger_fs/* $contract_dir/contract_fs/*
     mkdir -p $contract_dir/contract_fs/seed
-    cp -r $bundle_mount $contract_dir/contract_fs/seed/state
+    cp -r $bundle_mount/. $contract_dir/contract_fs/seed/state
     [ -d $contract_dir/contract_fs/seed/state/$disparate_dir ] && rm -r $contract_dir/contract_fs/seed/state/$disparate_dir
 
     # Copy non-syncable files if exist.


### PR DESCRIPTION
## Bug

When using `HP_DEVKIT_IMAGE=evernode/hpdevkit:0.6.5-beta` with `HP_INSTANCE_IMAGE=evernode/hotpocket:0.6.5-beta-ubt.20.04-njs.20`, contracts fail to deploy with the following errors on every ledger:

Contract process chdir failed.
[err][hpc] Consensus contract execution failed.
[err][hpc] Error occured when closing ledger
## Root Cause

In `sync_instance` in `docker/scripts/cluster.sh`:
```bash
# BROKEN
cp -r $bundle_mount $contract_dir/contract_fs/seed/state
```

This copies the `contract_bundle` **directory itself** into `seed/state`, resulting in files landing at `seed/state/contract_bundle/index.js` instead of `seed/state/index.js`.

This means `hp.cfg.override` is never found or merged, leaving `bin_path` as `"<your contract binary here>"` — causing HotPocket to fail when trying to execute the contract.

## Fix
```bash
# FIXED
cp -r $bundle_mount/. $contract_dir/contract_fs/seed/state
```

Using `/.` copies the **contents** of the bundle directory rather than the directory itself.

## Testing

Tested on Ubuntu 20.04 with:
- `HP_DEVKIT_IMAGE=evernode/hpdevkit:0.6.5-beta`
- `HP_INSTANCE_IMAGE=evernode/hotpocket:0.6.5-beta-ubt.20.04-njs.20`
- hpdevkit npm v0.6.8

After fix: cluster reaches consensus, contract executes correctly, full client round-trip confirmed working.

After merging, the `evernode/hpdevkit:0.6.5-beta` Docker image on Docker Hub will need to be rebuilt and pushed to pick up this fix. Users setting `HP_DEVKIT_IMAGE=evernode/hpdevkit:0.6.5-beta` will continue to experience `Contract process chdir failed` until the image is updated.