### PR TITLE
Add guard for empty disparate_dir in sync_instance

### DIFF
--- a/docker/scripts/cluster.sh
+++ b/docker/scripts/cluster.sh
@@ -278,7 +278,7 @@ function sync_instance {
     rm -rf $contract_dir/ledger_fs/* $contract_dir/contract_fs/*
     mkdir -p $contract_dir/contract_fs/seed
     cp -r $bundle_mount/. $contract_dir/contract_fs/seed/state
-    [ -d $contract_dir/contract_fs/seed/state/$disparate_dir ] && rm -r $contract_dir/contract_fs/seed/state/$disparate_dir
+    [ -n "$disparate_dir" ] && [ -d $contract_dir/contract_fs/seed/state/$disparate_dir ] && rm -r $contract_dir/contract_fs/seed/state/$disparate_dir
 
     # Copy non-syncable files if exist.
     [ -d "$bundle_mount/$disparate_dir/$i" ] && cp -r "$bundle_mount/$disparate_dir/$i/." "$contract_dir/contract_fs/seed/"


### PR DESCRIPTION
## Change

Add a guard to the `disparate_dir` cleanup in `sync_instance` to  prevent accidental deletion of the contract state directory when  `DISPARATE_DIR` is not set.

## Background

The `disparate` directory feature was introduced in the beta devkit  image to support multisig deployments. The cluster script assumes  `DISPARATE_DIR` is always set, however older NPM packages (below  v0.6.8) do not pass this environment variable, leaving `$disparate_dir`  as an empty string.

With an empty `$disparate_dir` this line:
```bash
[ -d $contract_dir/contract_fs/seed/state/$disparate_dir ] && rm -r $contract_dir/contract_fs/seed/state/$disparate_dir
```

Evaluates to:
```bash
[ -d $contract_dir/contract_fs/seed/state/ ] && rm -r $contract_dir/contract_fs/seed/state/
```

Deleting the entire state directory immediately after the contract  bundle is copied in.

## Change

Add a guard so the deletion only runs when `$disparate_dir` is  actually set:
```bash
# Before
[ -d $contract_dir/contract_fs/seed/state/$disparate_dir ] && rm -r $contract_dir/contract_fs/seed/state/$disparate_dir

# After
[ -n "$disparate_dir" ] && [ -d $contract_dir/contract_fs/seed/state/$disparate_dir ] && rm -r $contract_dir/contract_fs/seed/state/$disparate_dir
```

## Notes

- NPM v0.6.8 correctly passes `DISPARATE_DIR=disparate` and is  required for full beta devkit compatibility
- This guard is defensive programming to protect against the state  directory being accidentally deleted if an older NPM package is used  with the beta image
- For non-multisig deployments the disparate directory cleanup is  skipped entirely which is the correct behaviour